### PR TITLE
Add initial Torus wallet integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10769,6 +10769,11 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
+    "graphql": {
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
+      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA=="
+    },
     "graphql-tag": {
       "version": "2.12.4",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1202,7 +1202,6 @@
       "version": "7.13.17",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.17.tgz",
       "integrity": "sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -2413,6 +2412,25 @@
         "fastq": "^1.6.0"
       }
     },
+    "@popperjs/core": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
+      "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q=="
+    },
+    "@restart/context": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@restart/context/-/context-2.1.4.tgz",
+      "integrity": "sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q=="
+    },
+    "@restart/hooks": {
+      "version": "0.3.26",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.3.26.tgz",
+      "integrity": "sha512-7Hwk2ZMYm+JLWcb7R9qIXk1OoUg1Z+saKWqZXlrvFwT3w6UArVNWgxYOzf+PJoK9zZejp8okPAKTctthhXLt5g==",
+      "requires": {
+        "lodash": "^4.17.20",
+        "lodash-es": "^4.17.20"
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
@@ -2595,6 +2613,14 @@
         "@types/node": "*"
       }
     },
+    "@types/classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-zeOWb0JGBoVmlQoznvqXbE0tEC/HONsnoUNH19Hc96NFsTAwTXbTqb8FMYkru1F/iqp7a18Ws3nWJvtA1sHD1A==",
+      "requires": {
+        "classnames": "*"
+      }
+    },
     "@types/eslint": {
       "version": "7.2.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.10.tgz",
@@ -2645,6 +2671,11 @@
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
       "integrity": "sha512-giAlZwstKbmvMk1OO7WXSj4OZ0keXAcl2TQq4LWHiiPH2ByaH7WeUzng+Qej8UPxxv+8lRTuouo0iaNDBuzIBA==",
       "dev": true
+    },
+    "@types/invariant": {
+      "version": "2.2.34",
+      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.34.tgz",
+      "integrity": "sha512-lYUtmJ9BqUN688fGY1U1HZoWT1/Jrmgigx2loq4ZcJpICECm/Om3V314BxdzypO0u5PORKGMM6x0OXaljV1YFg=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -2724,8 +2755,7 @@
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-      "dev": true
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/q": {
       "version": "1.5.4",
@@ -2738,7 +2768,6 @@
       "version": "17.0.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.3.tgz",
       "integrity": "sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2754,11 +2783,18 @@
         "@types/react": "*"
       }
     },
+    "@types/react-transition-group": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-vIo69qKKcYoJ8wKCJjwSgCTM+z3chw3g18dkrDfVX665tMH7tmbDxEAnPdey4gTlwZz5QuHGzd+hul0OVZDqqQ==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/scheduler": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
-      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==",
-      "dev": true
+      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
     },
     "@types/secp256k1": {
       "version": "4.0.2",
@@ -2773,6 +2809,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
       "dev": true
+    },
+    "@types/warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI="
     },
     "@types/yargs": {
       "version": "15.0.13",
@@ -6146,6 +6187,11 @@
         }
       }
     },
+    "classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+    },
     "clean-css": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
@@ -7604,8 +7650,7 @@
     "csstype": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
-      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
-      "dev": true
+      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -8117,6 +8162,15 @@
       "dev": true,
       "requires": {
         "utila": "~0.4"
+      }
+    },
+    "dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "requires": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "dom-serializer": {
@@ -11603,7 +11657,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -13989,6 +14042,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -15785,6 +15843,22 @@
         }
       }
     },
+    "prop-types-extra": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
+      "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
+      "requires": {
+        "react-is": "^16.3.2",
+        "warning": "^4.0.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -15932,6 +16006,31 @@
         "object-assign": "^4.1.1"
       }
     },
+    "react-bootstrap": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.5.2.tgz",
+      "integrity": "sha512-mGKPY5+lLd7Vtkx2VFivoRkPT4xAHazuFfIhJLTEgHlDfIUSePn7qrmpZe5gXH9zvHV0RsBaQ9cLfXjxnZrOpA==",
+      "requires": {
+        "@babel/runtime": "^7.13.8",
+        "@restart/context": "^2.1.4",
+        "@restart/hooks": "^0.3.26",
+        "@types/classnames": "^2.2.10",
+        "@types/invariant": "^2.2.33",
+        "@types/prop-types": "^15.7.3",
+        "@types/react": ">=16.9.35",
+        "@types/react-transition-group": "^4.4.1",
+        "@types/warning": "^3.0.0",
+        "classnames": "^2.2.6",
+        "dom-helpers": "^5.1.2",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.7.2",
+        "prop-types-extra": "^1.1.0",
+        "react-overlays": "^5.0.0",
+        "react-transition-group": "^4.4.1",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      }
+    },
     "react-dom": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
@@ -15976,8 +16075,33 @@
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "dev": true
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-overlays": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.0.1.tgz",
+      "integrity": "sha512-plwUJieTBbLSrgvQ4OkkbTD/deXgxiJdNuKzo6n1RWE3OVnQIU5hffCGS/nvIuu6LpXFs2majbzaXY8rcUVdWA==",
+      "requires": {
+        "@babel/runtime": "^7.13.8",
+        "@popperjs/core": "^2.8.6",
+        "@restart/hooks": "^0.3.26",
+        "@types/warning": "^3.0.0",
+        "dom-helpers": "^5.2.0",
+        "prop-types": "^15.7.2",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      }
+    },
+    "react-transition-group": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      }
     },
     "read-pkg": {
       "version": "1.1.0",
@@ -16100,8 +16224,7 @@
     "regenerator-runtime": {
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-      "dev": true
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -18593,6 +18716,17 @@
         }
       }
     },
+    "uncontrollable": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
+      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
+      "requires": {
+        "@babel/runtime": "^7.6.3",
+        "@types/react": ">=16.9.11",
+        "invariant": "^2.2.4",
+        "react-lifecycles-compat": "^3.0.4"
+      }
+    },
     "underscore": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
@@ -18906,6 +19040,14 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.x"
+      }
+    },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1230,6 +1230,11 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@chaitanyapotti/random-id": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@chaitanyapotti/random-id/-/random-id-1.0.3.tgz",
+      "integrity": "sha512-xiVWA2vTL3jQeuZ+yebXAtwIeEbh/13RAFxvRq0YxeUc02RBOGyC9eyDKXjwlN0uxPtnEwWxsELkSwnaH5kxjg=="
+    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -2104,6 +2109,11 @@
         }
       }
     },
+    "@metamask/safe-event-emitter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz",
+      "integrity": "sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q=="
+    },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.tgz",
@@ -2181,6 +2191,106 @@
       "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
       "requires": {
         "defer-to-connect": "^1.0.1"
+      }
+    },
+    "@toruslabs/eccrypto": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@toruslabs/eccrypto/-/eccrypto-1.1.6.tgz",
+      "integrity": "sha512-L3TAsdEARouyzTbSKE0PqcYXmHQiFh95FB2YnsRbWERCAF0VWg3kY/YA//M/HBZqCJoRwa5WRA61lWbM7zAX5Q==",
+      "requires": {
+        "acorn": "^7.4.0",
+        "elliptic": "^6.5.3",
+        "es6-promise": "^4.2.8",
+        "nan": "^2.14.1",
+        "secp256k1": "^3.8.0"
+      },
+      "dependencies": {
+        "secp256k1": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+          "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "bip66": "^1.1.5",
+            "bn.js": "^4.11.8",
+            "create-hash": "^1.2.0",
+            "drbg.js": "^1.0.1",
+            "elliptic": "^6.5.2",
+            "nan": "^2.14.0",
+            "safe-buffer": "^5.1.2"
+          }
+        }
+      }
+    },
+    "@toruslabs/fetch-node-details": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@toruslabs/fetch-node-details/-/fetch-node-details-2.4.0.tgz",
+      "integrity": "sha512-aPk3dYdvEe9MuHiqPAdr3QYP3cR2+SB2pU2VFx3F7fjNBfxplfhNYTw+aAkzX54Uwrrr4zSsBjFcst8p9P8vAg==",
+      "requires": {
+        "web3-eth-contract": "^1.3.4",
+        "web3-utils": "^1.3.4"
+      }
+    },
+    "@toruslabs/http-helpers": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@toruslabs/http-helpers/-/http-helpers-1.3.7.tgz",
+      "integrity": "sha512-UcoFUBb74sD5bPRSXHtJRi1X3Q4reqd1a1nqekDuoZ9csadabNddUwd1CJ3kqaKiNWIe6lqB7E/XnwVMC39xdA==",
+      "requires": {
+        "deepmerge": "^4.2.2"
+      }
+    },
+    "@toruslabs/torus-embed": {
+      "version": "1.10.9",
+      "resolved": "https://registry.npmjs.org/@toruslabs/torus-embed/-/torus-embed-1.10.9.tgz",
+      "integrity": "sha512-Nm2pBNbQNDgvCU0n0WelDzQSvJwU/cSKSXl9g/lWrcqOTmDiSGtnIn+oGtfVSgWa9oaUbD7eIKBHNTdiDMf8Bw==",
+      "requires": {
+        "@chaitanyapotti/random-id": "^1.0.3",
+        "@toruslabs/fetch-node-details": "^2.4.0",
+        "@toruslabs/http-helpers": "^1.3.7",
+        "@toruslabs/torus.js": "^2.3.0",
+        "create-hash": "^1.2.0",
+        "deepmerge": "^4.2.2",
+        "eth-rpc-errors": "^4.0.3",
+        "fast-deep-equal": "^3.1.3",
+        "is-stream": "^2.0.0",
+        "json-rpc-engine": "^6.1.0",
+        "json-rpc-middleware-stream": "^3.0.0",
+        "loglevel": "^1.7.1",
+        "obj-multiplex": "^1.0.0",
+        "obs-store": "^4.0.3",
+        "post-message-stream": "^3.0.0",
+        "pump": "^3.0.0",
+        "safe-event-emitter": "^1.0.1"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        }
+      }
+    },
+    "@toruslabs/torus.js": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@toruslabs/torus.js/-/torus.js-2.3.0.tgz",
+      "integrity": "sha512-ar/14QE2MST53Cpdtto13L6AlN53IOM0LRS7uuFk7a8TFeI+RbeQquY68lgn3ESEhDPzAxOuLJ3s6M3nBA1arg==",
+      "requires": {
+        "@toruslabs/eccrypto": "^1.1.5",
+        "@toruslabs/http-helpers": "^1.3.5",
+        "bn.js": "^5.1.3",
+        "elliptic": "^6.5.4",
+        "json-stable-stringify": "^1.0.1",
+        "loglevel": "^1.7.1",
+        "memory-cache": "^0.2.0",
+        "web3-utils": "^1.3.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        }
       }
     },
     "@types/babel__core": {
@@ -2777,8 +2887,7 @@
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -4800,10 +4909,18 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
       "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "optional": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "bl": {
@@ -6270,8 +6387,7 @@
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "default-gateway": {
       "version": "4.2.0",
@@ -6648,6 +6764,17 @@
         }
       }
     },
+    "drbg.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+      "optional": true,
+      "requires": {
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
+      }
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -6837,6 +6964,11 @@
       "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
       "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
       "dev": true
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "es6-symbol": {
       "version": "3.1.3",
@@ -7296,6 +7428,14 @@
         }
       }
     },
+    "eth-rpc-errors": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-4.0.3.tgz",
+      "integrity": "sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==",
+      "requires": {
+        "fast-safe-stringify": "^2.0.6"
+      }
+    },
     "ethereum-bloom-filters": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.9.tgz",
@@ -7388,8 +7528,7 @@
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "eventsource": {
       "version": "1.1.0",
@@ -7947,6 +8086,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
     "fast-xml-parser": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
@@ -8061,7 +8205,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
       "optional": true
     },
     "filename-reserved-regex": {
@@ -9857,8 +10000,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -11561,6 +11703,24 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
+    "json-rpc-engine": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-6.1.0.tgz",
+      "integrity": "sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==",
+      "requires": {
+        "@metamask/safe-event-emitter": "^2.0.0",
+        "eth-rpc-errors": "^4.0.2"
+      }
+    },
+    "json-rpc-middleware-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-middleware-stream/-/json-rpc-middleware-stream-3.0.0.tgz",
+      "integrity": "sha512-JmZmlehE0xF3swwORpLHny/GvW3MZxCsb2uFNBrn8TOqMqivzCfz232NSDLLOtIQlrPlgyEjiYpyzyOPFOzClw==",
+      "requires": {
+        "@metamask/safe-event-emitter": "^2.0.0",
+        "readable-stream": "^2.3.3"
+      }
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -11570,6 +11730,14 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -11604,6 +11772,11 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -11797,8 +11970,7 @@
     "loglevel": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
-      "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==",
-      "dev": true
+      "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw=="
     },
     "longest": {
       "version": "1.0.1",
@@ -11931,6 +12103,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "memory-cache": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
+      "integrity": "sha1-eJCwHVLADI68nVM+H46xfjA0hxo="
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -12228,8 +12405,7 @@
     "nan": {
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "dev": true
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
     "nano-json-stream-parser": {
       "version": "0.1.2",
@@ -12619,6 +12795,16 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
+    "obj-multiplex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/obj-multiplex/-/obj-multiplex-1.0.0.tgz",
+      "integrity": "sha1-Lyrmv9SuEb7+dC6p6ls2Y26r/8E=",
+      "requires": {
+        "end-of-stream": "^1.4.0",
+        "once": "^1.4.0",
+        "readable-stream": "^2.3.3"
+      }
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -12758,6 +12944,17 @@
       "integrity": "sha1-VVQoTFQ6ImbXo48X4HOCH73jk80=",
       "requires": {
         "http-https": "^1.0.0"
+      }
+    },
+    "obs-store": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/obs-store/-/obs-store-4.0.3.tgz",
+      "integrity": "sha512-+mm13kCRDv6IcvUDKTw0LIy5+dQhIktYaR/RwwZUFzOTi/fjMaNBnk42Adb94qZqJ00qWkjhQSZH7MXlKnTi8A==",
+      "requires": {
+        "readable-stream": "^2.2.2",
+        "safe-event-emitter": "^1.0.1",
+        "through2": "^2.0.3",
+        "xtend": "^4.0.1"
       }
     },
     "obuf": {
@@ -13303,6 +13500,14 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "post-message-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/post-message-stream/-/post-message-stream-3.0.0.tgz",
+      "integrity": "sha1-kNn1S9IJ5rb110eVuHWIIFtUcEg=",
+      "requires": {
+        "readable-stream": "^2.1.4"
+      }
+    },
     "postcss": {
       "version": "8.2.12",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.12.tgz",
@@ -13461,8 +13666,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -13755,7 +13959,6 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -14167,6 +14370,14 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safe-event-emitter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safe-event-emitter/-/safe-event-emitter-1.0.1.tgz",
+      "integrity": "sha512-e1wFe99A91XYYxoQbcq2ZJUWurxEyP8vfz7A7vuUe1s95q8r5ebraVaA1BukYJcpM6V16ugWoD9vngi8Ccu5fg==",
+      "requires": {
+        "events": "^3.0.0"
+      }
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -15815,6 +16026,15 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true,
       "optional": true
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
     },
     "thunky": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -86,15 +86,16 @@
     "webpack-merge": "^5.7.3"
   },
   "dependencies": {
-    "@toruslabs/torus-embed": "^1.10.9",
     "@aave/protocol-js": "^2.7.2",
     "@apollo/react-hooks": "^4.0.0",
+    "@toruslabs/torus-embed": "^1.10.9",
     "apollo-boost": "^0.4.9",
     "apollo-client": "^2.6.10",
     "apollo-utilities": "^1.3.4",
     "bootstrap": "^4.6.0",
     "buffer": "^6.0.3",
     "ethers": "^5.1.4",
+    "graphql": "^15.5.0",
     "os-browserify": "^0.3.0",
     "web3": "^1.3.5"
   }

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "webpack-merge": "^5.7.3"
   },
   "dependencies": {
+    "@toruslabs/torus-embed": "^1.10.9",
     "buffer": "^6.0.3",
     "os-browserify": "^0.3.0",
     "web3": "^1.3.5"

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "ethers": "^5.1.4",
     "graphql": "^15.5.0",
     "os-browserify": "^0.3.0",
+    "react-bootstrap": "^1.5.2",
     "web3": "^1.3.5"
   }
 }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,18 +1,21 @@
+import { v2 } from "@aave/protocol-js";
+import Torus from "@toruslabs/torus-embed";
 import * as React from "react";
 import { hot } from "react-hot-loader";
+import Web3 from "web3";
+import { initializeTorusConnection, signUserIntoTorus } from "../web3/wallet";
 import { ExtendedWeb3WindowInterface } from "../web3/web3";
-import { initializeWallet } from "../web3/wallet";
+import "./../assets/scss/App.scss";
 import { AaveClient } from "./Data/AaveClient";
 import { V2_RESERVES, V2_USER_RESERVES } from "./Data/Query.js";
-import { v2 } from "@aave/protocol-js";
-
+import Button from "react-bootstrap/Button";
 const reactLogo = require("./../assets/img/react_logo.svg");
-import "./../assets/scss/App.scss";
 
 export interface Web3Account {}
 
 export interface AppState {
   isVerified: boolean;
+  torus?: Torus;
   userReserves: string[];
 }
 
@@ -27,10 +30,14 @@ class App extends React.Component<Record<string, unknown>, AppState> {
       isVerified: false,
       userReserves: [],
     };
+
+    // Need to bind to this since this function is called from the DOM.
+    this.signUserIn = this.signUserIn.bind(this);
   }
 
   private async getAccountInfo() {
-    this.web3 = await initializeWallet();
+    // Must pass in Torus provider in order for Web3 to not use MetaMask by default.
+    this.web3 = new Web3(this.state.torus.provider);
     this.mainAccount = (await this.web3.eth.getAccounts())[0];
     console.log("MAIN ACCOUNT: ", this.mainAccount);
     this.setState({
@@ -84,8 +91,26 @@ class App extends React.Component<Record<string, unknown>, AppState> {
     return v2UserSummary;
   }
 
+  // This function creates the connection to the Torus wallet when the application loads up.
+  private async setUpTorus() {
+    this.setState({ torus: await initializeTorusConnection() });
+  }
+
+  private async signUserIn() {
+    if (!this.state.torus) return;
+    try {
+      // If successfully logs in then user hash is returned.
+      await signUserIntoTorus(this.state.torus);
+      // Once user is logged in then we can finish web3 set-up.
+      await this.getAccountInfo();
+    } catch (e) {
+      //TODO(adotcruz): Handle the case where the user can't log-in cleanly.
+      console.log("could not log user in successfully");
+    }
+  }
+
   componentDidMount() {
-    this.getAccountInfo();
+    this.setUpTorus();
   }
 
   public render() {
@@ -98,22 +123,28 @@ class App extends React.Component<Record<string, unknown>, AppState> {
           {this.state.isVerified ? (
             <div>
               <h4 className="font-weight-light">Hello, {this.mainAccount}</h4>
+              <div className="user-wallet-info shadow-lg p-3 mb-5 bg-white rounded">
+                <h3>
+                  Holdings in Aave (Polygon)
+                  <img
+                    src="https://pbs.twimg.com/profile_images/1186270065085370368/J1YJtvdI.jpg"
+                    height="30"
+                    className="rounded ml-2"
+                  />
+                </h3>
+                {this.state.userReserves}
+              </div>
             </div>
           ) : (
-            <h3>not verified :(</h3>
+            <div>
+              <h3>not verified :(</h3>
+              {this.state.torus ? (
+                <Button onClick={this.signUserIn}>Sign in!</Button>
+              ) : (
+                ""
+              )}
+            </div>
           )}
-        </div>
-
-        <div className="user-wallet-info shadow-lg p-3 mb-5 bg-white rounded">
-          <h3>
-            Holdings in Aave (Polygon)
-            <img
-              src="https://pbs.twimg.com/profile_images/1186270065085370368/J1YJtvdI.jpg"
-              height="30"
-              className="rounded ml-2"
-            />
-          </h3>
-          {this.state.userReserves}
         </div>
       </div>
     );

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { hot } from "react-hot-loader";
 import getWeb3, { ExtendedWeb3WindowInterface } from "../web3/web3";
+import { initializeWallet } from "../web3/wallet";
 
 const reactLogo = require("./../assets/img/react_logo.svg");
 import "./../assets/scss/App.scss";
@@ -24,12 +25,13 @@ class App extends React.Component<Record<string, unknown>, AppState> {
   }
 
   private async setUpWeb3() {
-    this.web3 = await getWeb3();
-    this.mainAccount = (await this.web3.eth.getAccounts())[0];
-    console.log(this.mainAccount);
-    this.setState({
-      isVerified: true,
-    });
+    this.web3 = await initializeWallet();
+    // this.web3 = await getWeb3();
+    // this.mainAccount = (await this.web3.eth.getAccounts())[0];
+    // console.log(this.mainAccount);
+    // this.setState({
+    //   isVerified: true,
+    // });
   }
 
   componentDidMount() {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -40,7 +40,7 @@ class App extends React.Component<Record<string, unknown>, AppState> {
     return (
       <div className="app">
         <h1>Hello World!</h1>
-        <p>Foo to the barz nice</p>
+        <p>Foo to the bar nice</p>
         <img src={reactLogo.default} height="480" />
         {this.state.isVerified ? (
           <div>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -31,7 +31,7 @@ class App extends React.Component<Record<string, unknown>, AppState> {
       userReserves: [],
     };
 
-    // Need to bind to this since this function is called from the DOM.
+    // Need to bind to `this` since this function is called from the DOM, where this loses its scope.
     this.signUserIn = this.signUserIn.bind(this);
   }
 
@@ -96,6 +96,10 @@ class App extends React.Component<Record<string, unknown>, AppState> {
     this.setState({ torus: await initializeTorusConnection() });
   }
 
+  // This is the last function with Torus set-up.
+  //
+  // This is called when a user clicks the button to sign-in through Torus and finishes up initialization
+  // of Web3.js by adding the Torus provider.
   private async signUserIn() {
     if (!this.state.torus) return;
     try {

--- a/src/web3/wallet.ts
+++ b/src/web3/wallet.ts
@@ -1,0 +1,23 @@
+import Torus from "@toruslabs/torus-embed";
+import Web3 from "web3";
+
+export const initializeWallet: () => Promise<Web3> = async (): Promise<Web3> => {
+  const torus = new Torus({
+    buttonPosition: "top-left", // default: bottom-left
+  });
+  await torus.init({
+    buildEnv: "production", // default: production
+    enableLogging: true, // default: false
+    network: {
+      host: "mumbai", // default: mainnet
+      chainId: 80001, // default: 1
+      networkName: "Mumbai Test Network", // default: Main Ethereum Network
+    },
+    showTorusButton: true, // default: true
+  });
+  console.log("torus has init");
+  await torus.login({}); // await torus.ethereum.enable()
+  console.log("torus has logged in");
+  console.log("here");
+  return new Web3(torus.provider);
+};

--- a/src/web3/wallet.ts
+++ b/src/web3/wallet.ts
@@ -1,6 +1,36 @@
 import Torus from "@toruslabs/torus-embed";
 import Web3 from "web3";
 
+// This function creates the connection to the Torus api.
+//
+// The configuration passed into `torus.init` is what determines which network Torus is on, as well
+// as other block chain information
+export const initializeTorusConnection: () => Promise<Torus> = async (): Promise<Torus> => {
+  const torus = new Torus({
+    buttonPosition: "top-left", // default: bottom-left
+  });
+  await torus.init({
+    buildEnv: "production", // default: production
+    enableLogging: true, // default: false
+    network: {
+      host: "mumbai", // default: mainnet
+      chainId: 80001, // default: 1
+      networkName: "Mumbai Test Network", // default: Main Ethereum Network
+    },
+    showTorusButton: true, // default: true
+  });
+  return torus;
+};
+
+// Function opens Torus modal for user to sign-in.
+//
+// If user signs in successfully then account hash is returned
+export const signUserIntoTorus = (torus: Torus): Promise<string[]> => {
+  return torus.login({}); // await torus.ethereum.enable()
+};
+
+// Function is unsued but leaving here for reference in case we ever want to do it all
+// one step.
 export const initializeWallet: () => Promise<Web3> = async (): Promise<Web3> => {
   const torus = new Torus({
     buttonPosition: "top-left", // default: bottom-left

--- a/src/web3/web3.ts
+++ b/src/web3/web3.ts
@@ -8,8 +8,8 @@ interface EthExtendedProperties {
   getAccounts: () => Promise<any[]>;
 }
 export interface ExtendedWeb3WindowInterface {
-  ethereum: any;
-  web3: Web3ExtendedProperties;
+  ethereum?: any;
+  web3?: Web3ExtendedProperties;
   eth;
 }
 


### PR DESCRIPTION
This PR adds Torus as the Web3 provider.

This CL also breaks up wallet logic into 3 steps:

1. Torus api is initialized for application to use.
2. User logs in and authorizes for use of Torus wallet
3. After a user is logged in, Web3 is initialized for the application.

I also added react-bootstrap + bootstrap for use of components.

I had to `npm i graphql` because it is a peer dependency for some of the other graphql node modules we use.