### PR TITLE
[wip] lending on aave

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+*.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 dist
-*.lock
+*lock

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,7 +3,7 @@ import { hot } from "react-hot-loader";
 import getWeb3, { ExtendedWeb3WindowInterface } from "../web3/web3";
 import { AaveClient } from "./Data/AaveClient";
 import { V2_RESERVES, V2_USER_RESERVES } from "./Data/Query.js";
-import { v2 } from "@aave/protocol-js";
+import { v2, TxBuilderV2, Network, Market } from "@aave/protocol-js";
 
 const reactLogo = require("./../assets/img/react_logo.svg");
 import "./../assets/scss/App.scss";
@@ -17,7 +17,6 @@ export interface AppState {
 
 class App extends React.Component<Record<string, unknown>, AppState> {
   private web3: ExtendedWeb3WindowInterface;
-
   private mainAccount?: Web3Account;
 
   constructor(props) {
@@ -30,6 +29,7 @@ class App extends React.Component<Record<string, unknown>, AppState> {
 
   private async getAccountInfo() {
     this.web3 = await getWeb3();
+
     this.mainAccount = (await this.web3.eth.getAccounts())[0];
     console.log("MAIN ACCOUNT: ", this.mainAccount);
     this.setState({
@@ -39,6 +39,25 @@ class App extends React.Component<Record<string, unknown>, AppState> {
     // TODO: fetch real ETH price
     const ethPriceUsd = 2700;
     this.fetchAave(this.mainAccount, ethPriceUsd);
+
+    const httpProvider = this.web3.eth.providers["HttpProvider"];
+    console.log("current web3 provider: ", httpProvider);
+
+    const txBuilder = new TxBuilderV2(Network.mainnet, httpProvider);
+
+    console.log("txbuilder: ", txBuilder);
+
+    const lendingPool = txBuilder.getLendingPool(Market.Proto); // get all lending pool methods
+
+    console.log("lending pool: ", lendingPool);
+
+    //   lendingPool.deposit({
+    //     user, // string,
+    //     reserve, // string,
+    //     amount, // string,
+    //     onBehalfOf, // ? string,
+    //     referralCode, // ? string,
+    //  });
   }
 
   // TODO: move to other module like aave-utils

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4,6 +4,8 @@ import getWeb3, { ExtendedWeb3WindowInterface } from "../web3/web3";
 import { AaveClient } from "./Data/AaveClient";
 import { V2_RESERVES, V2_USER_RESERVES } from "./Data/Query.js";
 import { v2, TxBuilderV2, Network, Market } from "@aave/protocol-js";
+import { EthereumTransactionTypeExtended } from "@aave/protocol-js";
+import Web3 from "web3";
 
 const reactLogo = require("./../assets/img/react_logo.svg");
 import "./../assets/scss/App.scss";
@@ -40,24 +42,31 @@ class App extends React.Component<Record<string, unknown>, AppState> {
     const ethPriceUsd = 2700;
     this.fetchAave(this.mainAccount, ethPriceUsd);
 
-    const httpProvider = this.web3.eth.providers["HttpProvider"];
+    // TODO: confirm which provider -- alternative below
+    // const httpProvider = this.web3.eth.providers["HttpProvider"];
+
+    const httpProvider = new Web3.providers.HttpProvider(
+      "https://mainnet.infura.io/v3/a305eb1a2c9b42cdbcf61db762f8243e"
+    );
+
     console.log("current web3 provider: ", httpProvider);
 
-    const txBuilder = new TxBuilderV2(Network.mainnet, httpProvider);
+    let txBuilder;
+    let lendingPool;
 
+    txBuilder = new TxBuilderV2(Network.mainnet, httpProvider);
     console.log("txbuilder: ", txBuilder);
 
-    const lendingPool = txBuilder.getLendingPool(Market.Proto); // get all lending pool methods
-
+    lendingPool = txBuilder.getLendingPool(Market.Proto); // get all lending pool methods
     console.log("lending pool: ", lendingPool);
 
-    //   lendingPool.deposit({
-    //     user, // string,
-    //     reserve, // string,
-    //     amount, // string,
-    //     onBehalfOf, // ? string,
-    //     referralCode, // ? string,
-    //  });
+    let lendingResponse = await lendingPool.deposit({
+      user: "0xC33D36523FBF8360792C2c372f5fE457BeeC001f",
+      reserve: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      amount: "10000",
+    });
+
+    console.log("response from lending: ", lendingResponse);
   }
 
   // TODO: move to other module like aave-utils

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,11 +3,9 @@ import { hot } from "react-hot-loader";
 import getWeb3, { ExtendedWeb3WindowInterface } from "../web3/web3";
 import { AaveClient } from "./Data/AaveClient";
 import { V2_RESERVES, V2_USER_RESERVES } from "./Data/Query.js";
-import { v2, TxBuilderV2, Network, Market } from "@aave/protocol-js";
-import { EthereumTransactionTypeExtended } from "@aave/protocol-js";
-import Web3 from "web3";
+import { v2 } from "@aave/protocol-js";
+import { deposit } from "./Lend/AaveAction";
 
-const reactLogo = require("./../assets/img/react_logo.svg");
 import "./../assets/scss/App.scss";
 
 export interface Web3Account {}
@@ -42,34 +40,12 @@ class App extends React.Component<Record<string, unknown>, AppState> {
     const ethPriceUsd = 2700;
     this.fetchAave(this.mainAccount, ethPriceUsd);
 
-    // TODO: confirm which provider -- alternative below
-    // const httpProvider = this.web3.eth.providers["HttpProvider"];
-
-    const httpProvider = new Web3.providers.HttpProvider(
-      "https://mainnet.infura.io/v3/a305eb1a2c9b42cdbcf61db762f8243e"
-    );
-
-    console.log("current web3 provider: ", httpProvider);
-
-    let txBuilder;
-    let lendingPool;
-
-    txBuilder = new TxBuilderV2(Network.mainnet, httpProvider);
-    console.log("txbuilder: ", txBuilder);
-
-    lendingPool = txBuilder.getLendingPool(Market.Proto); // get all lending pool methods
-    console.log("lending pool: ", lendingPool);
-
-    let lendingResponse = await lendingPool.deposit({
-      user: "0xC33D36523FBF8360792C2c372f5fE457BeeC001f",
-      reserve: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-      amount: "10000",
-    });
-
-    console.log("response from lending: ", lendingResponse);
+    // deposit to Aave lending pool
+    let user = await this.web3.eth.getAccounts();
+    deposit(this.web3.eth.currentProvider, user[0]);
   }
 
-  // TODO: move to other module like aave-utils
+  // TODO: move to another module like aave-utils
   private async fetchAave(address, ethPrice) {
     let lowercaseAddress = address.toLowerCase();
     const v2Reserves = await AaveClient.query({

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -41,8 +41,8 @@ class App extends React.Component<Record<string, unknown>, AppState> {
     this.fetchAave(this.mainAccount, ethPriceUsd);
 
     // deposit to Aave lending pool
-    let user = await this.web3.eth.getAccounts();
-    deposit(this.web3.eth.currentProvider, user[0]);
+    let accounts = await this.web3.eth.getAccounts();
+    deposit(this.web3.eth.currentProvider, accounts[0]);
   }
 
   // TODO: move to another module like aave-utils

--- a/src/components/Lend/AaveAction.tsx
+++ b/src/components/Lend/AaveAction.tsx
@@ -1,0 +1,46 @@
+import { TxBuilderV2, Network, Market } from "@aave/protocol-js";
+import { ethers } from "ethers";
+
+export const deposit = async (provider, accountAddress) => {
+  let txBuilder;
+  let lendingPool;
+
+  let customProvider = new ethers.providers.Web3Provider(provider);
+  console.log("CUSTOM PROVIDER: ", customProvider);
+
+  txBuilder = new TxBuilderV2(Network.mainnet, customProvider);
+  console.log("txbuilder: ", txBuilder);
+
+  lendingPool = txBuilder.getLendingPool(Market.Proto); // get all lending pool methods
+  console.log("lending pool: ", lendingPool);
+
+  console.log("triggering lending pool deposit for user ", accountAddress);
+  // The lendingResponse a Promise array of ethereum transactions, which are executed with sendTransaction()
+  // https://github.com/aave/aave-js/tree/8c4131acef1a908d69a328a6925a1caf65df7375#lending-pool-v2
+  // TODO: update to take actual input for reserve and amount (remove hard-coding)
+  let lendingResponse = await lendingPool.deposit({
+    user: accountAddress,
+    // USDC reserve
+    reserve: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    amount: "10",
+  });
+
+  //   A Signer in ethers is an abstraction of an Ethereum Account, which can be used to sign messages and transactions
+  //   https://docs.ethers.io/v5/api/signer/
+  let signer = customProvider.getSigner();
+  console.log("CURRENT SIGNER", signer);
+
+  // Iterate through list of transactions, trigger them one by one
+  let results = [];
+  for (const t in lendingResponse) {
+    let currentTx = await lendingResponse[t].tx();
+    console.log("CURRENT TX: ", currentTx);
+    // submit the txn (needs to be signed by user)
+    let tx = await signer.sendTransaction(currentTx);
+    // we then wait for one block confirmation before sending the next request
+    let receipt = await tx.wait(1);
+    console.log("SENDING TX", lendingResponse[t].txType, tx, receipt);
+    results.push(tx);
+  }
+  console.log("ALL RESULTS: ", results);
+};

--- a/src/components/Lend/AaveAction.tsx
+++ b/src/components/Lend/AaveAction.tsx
@@ -2,23 +2,20 @@ import { TxBuilderV2, Network, Market } from "@aave/protocol-js";
 import { ethers } from "ethers";
 
 export const deposit = async (provider, accountAddress) => {
-  let txBuilder;
-  let lendingPool;
-
-  let customProvider = new ethers.providers.Web3Provider(provider);
+  const customProvider = new ethers.providers.Web3Provider(provider);
   console.log("CUSTOM PROVIDER: ", customProvider);
 
-  txBuilder = new TxBuilderV2(Network.mainnet, customProvider);
+  const txBuilder = new TxBuilderV2(Network.mainnet, customProvider);
   console.log("txbuilder: ", txBuilder);
 
-  lendingPool = txBuilder.getLendingPool(Market.Proto); // get all lending pool methods
+  const lendingPool = txBuilder.getLendingPool(Market.Proto); // get all lending pool methods
   console.log("lending pool: ", lendingPool);
 
   console.log("triggering lending pool deposit for user ", accountAddress);
   // The lendingResponse a Promise array of ethereum transactions, which are executed with sendTransaction()
   // https://github.com/aave/aave-js/tree/8c4131acef1a908d69a328a6925a1caf65df7375#lending-pool-v2
   // TODO: update to take actual input for reserve and amount (remove hard-coding)
-  let lendingResponse = await lendingPool.deposit({
+  const lendingResponse = await lendingPool.deposit({
     user: accountAddress,
     // USDC reserve
     reserve: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -27,11 +24,11 @@ export const deposit = async (provider, accountAddress) => {
 
   //   A Signer in ethers is an abstraction of an Ethereum Account, which can be used to sign messages and transactions
   //   https://docs.ethers.io/v5/api/signer/
-  let signer = customProvider.getSigner();
+  const signer = customProvider.getSigner();
   console.log("CURRENT SIGNER", signer);
 
   // Iterate through list of transactions, trigger them one by one
-  let results = [];
+  const results = [];
   for (const t in lendingResponse) {
     let currentTx = await lendingResponse[t].tx();
     console.log("CURRENT TX: ", currentTx);


### PR DESCRIPTION
Proof of concept for depositing on Aave ([docs](https://github.com/aave/aave-js/tree/8c4131acef1a908d69a328a6925a1caf65df7375#lending-pool-v2))
Triggers the transaction to deposit on an Aave lending pool. Normally it's just 1 step to deposit, but the first time requires 2 steps for approving the movement of the token itself. 
Defaulting to USDC for now. I think we can choose 1 type of token to start with.

Example transactions triggered:
1. [Approve USDC For Trade On Aave Lending Pool V2](https://etherscan.io/tx/0x9502cf6931c16064c4b784fbb2e70db09bafb2995126d64519bc823edb83887d)
2. [Supply to Aave Lending Pool](https://etherscan.io/tx/0x8857fcd8ab77cc01afd420177dfc8caa6f4d7391a161b1cdfaae7bef2f28429f)

## TODO 
- [ ] Flow should happen on button click, but now it's happening as soon as you load the page (for prototyping purposes)
- [ ] Amount is hard-coded. Should be based on either user input or funds in the wallet, and use the right decimal units
- [x] Update network to Polygon instead of ETH mainnet
