### PR TITLE
Add Zapper API integration that gets the current Ethereum price

### DIFF
--- a/configs/webpack/common.js
+++ b/configs/webpack/common.js
@@ -4,6 +4,7 @@ const { resolve } = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 require("babel-core/register");
 require("babel-polyfill");
+require("whatwg-fetch");
 
 module.exports = {
   entry: ["babel-polyfill"],

--- a/configs/webpack/dev.js
+++ b/configs/webpack/dev.js
@@ -13,6 +13,13 @@ module.exports = merge(commonConfig, {
   ],
   devServer: {
     hot: true, // enable HMR on the server
+    proxy: {
+      "/zapper": {
+        target: "https://api.zapper.fi",
+        pathRewrite: { "^/zapper": "" },
+        changeOrigin: true,
+      },
+    },
   },
   devtool: "cheap-module-source-map",
   plugins: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -20048,6 +20048,11 @@
         "iconv-lite": "0.4.24"
       }
     },
+    "whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
+    },
     "whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "graphql": "^15.5.0",
     "os-browserify": "^0.3.0",
     "react-bootstrap": "^1.5.2",
-    "web3": "^1.3.5"
+    "web3": "^1.3.5",
+    "whatwg-fetch": "^3.6.2"
   }
 }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -10,14 +10,16 @@ import "./../assets/scss/App.scss";
 import { AaveClient } from "./Data/AaveClient";
 import { V2_RESERVES, V2_USER_RESERVES } from "./Data/Query.js";
 import { deposit } from "./Lend/AaveAction";
+import { ZapperService } from "../services/ZapperService";
 const reactLogo = require("./../assets/img/react_logo.svg");
 
 export interface Web3Account {}
 
 export interface AppState {
   isVerified: boolean;
-  torus?: Torus;
   userReserves: string[];
+  currentEthPrice?: number;
+  torus?: Torus;
 }
 
 class App extends React.Component<Record<string, unknown>, AppState> {
@@ -27,6 +29,7 @@ class App extends React.Component<Record<string, unknown>, AppState> {
   constructor(props) {
     super(props);
     this.state = {
+      currentEthPrice: 0,
       isVerified: false,
       userReserves: [],
     };
@@ -119,6 +122,13 @@ class App extends React.Component<Record<string, unknown>, AppState> {
 
   componentDidMount() {
     this.setUpTorus();
+    this.getEthereumPrice();
+  }
+
+  private async getEthereumPrice() {
+    this.setState({
+      currentEthPrice: await ZapperService.GetEthereumPrice(),
+    });
   }
 
   public render() {
@@ -128,6 +138,11 @@ class App extends React.Component<Record<string, unknown>, AppState> {
           <h1 className="font-weight-lighter underline--magical-thick">
             Voltaire
           </h1>
+          {this.state.currentEthPrice != 0 ? (
+            <h4>Current Eth Price: {this.state.currentEthPrice}</h4>
+          ) : (
+            ""
+          )}
           {this.state.isVerified ? (
             <div>
               <h4 className="font-weight-light">Hello, {this.mainAccount}</h4>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -47,9 +47,7 @@ class App extends React.Component<Record<string, unknown>, AppState> {
       isVerified: true,
     });
 
-    // TODO: fetch real ETH price
-    const ethPriceUsd = 2700;
-    this.fetchAave(this.mainAccount, ethPriceUsd);
+    this.fetchAave(this.mainAccount, this.state.currentEthPrice);
 
     // deposit to Aave lending pool
     let accounts = await this.web3.eth.getAccounts();

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -125,6 +125,7 @@ class App extends React.Component<Record<string, unknown>, AppState> {
     this.getEthereumPrice();
   }
 
+  // Calls the Zapper API and gets the current Ethereum price on Polygon/Matic.
   private async getEthereumPrice() {
     this.setState({
       currentEthPrice: await ZapperService.GetEthereumPrice(),

--- a/src/models/Zapper.ts
+++ b/src/models/Zapper.ts
@@ -1,12 +1,17 @@
+// Zapper supported networks.
+//
+// We currently only care about Ethereum/Polygon (Matic).
 export enum ZapperNetworks {
   ethereum = "ethereum",
   polygon = "polygon",
 }
 
+// Zapper specific coin symbols to differentiate coins.
 export enum ZapperCoinSymbols {
   eth = "ETH",
 }
 
+// Response of `/price` endpoint.
 export interface ZapperCoinPrice {
   address: string;
   decimals: number;

--- a/src/models/Zapper.ts
+++ b/src/models/Zapper.ts
@@ -1,0 +1,15 @@
+export enum ZapperNetworks {
+  ethereum = "ethereum",
+  polygon = "polygon",
+}
+
+export enum ZapperCoinSymbols {
+  eth = "ETH",
+}
+
+export interface ZapperCoinPrice {
+  address: string;
+  decimals: number;
+  symbol: string;
+  price: number;
+}

--- a/src/services/HttpService.ts
+++ b/src/services/HttpService.ts
@@ -1,0 +1,16 @@
+export class HttpService {
+  // Returns a response body of type T if successful, if not then returns a generic
+  // HTTP response.
+  public static async get<T>(url: string): Promise<T | Response> {
+    const response = await fetch(url);
+    try {
+      const body = await response.json();
+      return body;
+    } catch (error) {
+      if (!response.ok) {
+        throw new Error(response.statusText);
+      }
+      return response;
+    }
+  }
+}

--- a/src/services/ZapperService.ts
+++ b/src/services/ZapperService.ts
@@ -1,0 +1,33 @@
+import { HttpService } from "./HttpService";
+import {
+  ZapperCoinPrice,
+  ZapperCoinSymbols,
+  ZapperNetworks,
+} from "../models/Zapper";
+
+const ZapperEndpoint = "/zapper";
+const ZapperApiKey = "96e0cc51-a62e-42ca-acee-910ea7d2a241";
+
+export class ZapperService {
+  static async GetEthereumPrice(
+    network: ZapperNetworks = ZapperNetworks.polygon
+  ): Promise<number> {
+    const priceEndpoint = `v1/prices?network=${network}&api_key=${ZapperApiKey}`;
+    try {
+      const coinPrices = (await HttpService.get<ZapperCoinPrice[]>(
+        `${ZapperEndpoint}/${priceEndpoint}`
+      )) as ZapperCoinPrice[];
+      console.log("coin prices fetched from zapper");
+      for (const coinPrice of coinPrices) {
+        if (coinPrice.symbol == ZapperCoinSymbols.eth) {
+          console.log("ethereum price was found");
+          return coinPrice.price;
+        }
+      }
+      return 0;
+    } catch (error) {
+      console.log("request failed", error);
+      return 0;
+    }
+  }
+}

--- a/src/services/ZapperService.ts
+++ b/src/services/ZapperService.ts
@@ -9,6 +9,9 @@ const ZapperEndpoint = "/zapper";
 const ZapperApiKey = "96e0cc51-a62e-42ca-acee-910ea7d2a241";
 
 export class ZapperService {
+  // This function gets the current Ethereum price on the specified `network`.
+  //
+  // Currently Voltaire only exists in Polygon, so we by default use the Polygon network.
   static async GetEthereumPrice(
     network: ZapperNetworks = ZapperNetworks.polygon
   ): Promise<number> {


### PR DESCRIPTION
Add Zapper API integration that allows us to get the current Ethereum price

This CL includes:

- Addition of WebPack proxy config settings to make an HTTP request from Chrome
- An HTTP service that makes a GET request (we need to update it for post/put as we use those HTTP methods)
- Addition of Zapper model classes to model the different JSON objects returned from the API
- Zapper Service that makes HTTP requests and then business logic on those requests

<img width="714" alt="Screen Shot 2021-05-04 at 12 15 51 AM" src="https://user-images.githubusercontent.com/16697901/116960286-f5c9fc00-ac6d-11eb-8bbe-bd1bf61a5cc2.png">
