### PR TITLE
Replace the url used to query for aave data

### DIFF
--- a/src/components/Data/AaveClient.js
+++ b/src/components/Data/AaveClient.js
@@ -1,16 +1,15 @@
-
 import { ApolloClient } from "apollo-client";
 import { InMemoryCache } from "apollo-cache-inmemory";
 import { HttpLink } from "apollo-link-http";
 
 export const AaveClient = new ApolloClient({
-    // By default, this client will send queries to the
-    //  `/graphql` endpoint on the same host
-    // Pass the configuration option { uri: YOUR_GRAPHQL_API_URL } to the `HttpLink` to connect
-    // to a different host
-    link: new HttpLink({
-        // pending uniswap with 'fixed' trade volumne
-        uri: "https://api.thegraph.com/subgraphs/name/aave/protocol-v2",
-    }),
-    cache: new InMemoryCache(),
+  // By default, this client will send queries to the
+  //  `/graphql` endpoint on the same host
+  // Pass the configuration option { uri: YOUR_GRAPHQL_API_URL } to the `HttpLink` to connect
+  // to a different host
+  link: new HttpLink({
+    // pending uniswap with 'fixed' trade volumne
+    uri: "https://api.thegraph.com/subgraphs/name/aave/aave-v2-matic",
+  }),
+  cache: new InMemoryCache(),
 });


### PR DESCRIPTION
New AAVE url comes from: https://docs.aave.com/developers/getting-started/using-graphql#aaves-subgraphs

Specifically the `mainnet` url.