### PR TITLE
Use Zapper API to get a users aave holdings.

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4,24 +4,25 @@ import * as React from "react";
 import Button from "react-bootstrap/Button";
 import { hot } from "react-hot-loader";
 import Web3 from "web3";
+import { ZapperAaveBalance } from "../models/Zapper";
+import { ZapperService } from "../services/ZapperService";
 import { initializeTorusConnection, signUserIntoTorus } from "../web3/wallet";
 import { ExtendedWeb3WindowInterface } from "../web3/web3";
 import "./../assets/scss/App.scss";
+import { UserHoldingsComponent } from "./account/UserHoldings";
 import { AaveClient } from "./Data/AaveClient";
 import { V2_RESERVES, V2_USER_RESERVES } from "./Data/Query.js";
 import { deposit } from "./Lend/AaveAction";
-import { ZapperService } from "../services/ZapperService";
-import { ZapperAaveBalance } from "../models/Zapper";
 const reactLogo = require("./../assets/img/react_logo.svg");
 
-export interface Web3Account {}
+export type Web3Account = string;
 
 export interface AppState {
   isVerified: boolean;
   userReserves: string[];
   aaveHoldings?: ZapperAaveBalance[];
   // Users wallet hash.
-  account?: string;
+  account?: Web3Account;
   currentEthPrice?: number;
   torus?: Torus;
 }
@@ -43,7 +44,7 @@ class App extends React.Component<Record<string, unknown>, AppState> {
   }
 
   // Get a users aave specific holdings.
-  private async getAaveTokenBalances(address: string) {
+  private async getAaveTokenBalances(address: Web3Account) {
     this.setState({
       aaveHoldings: await ZapperService.GetUserAaveHoldings(address),
     });
@@ -172,10 +173,10 @@ class App extends React.Component<Record<string, unknown>, AppState> {
               <div>
                 {this.state.aaveHoldings ? (
                   <div>
-                    {this.state.aaveHoldings[0].label}:{" "}
-                    {this.state.aaveHoldings[0].balanceUSD} USD
-                    <br />
-                    {this.state.aaveHoldings[0].balance}
+                    <h3>Aave Holdings</h3>
+                    <UserHoldingsComponent
+                      aaveHoldings={this.state.aaveHoldings}
+                    ></UserHoldingsComponent>
                   </div>
                 ) : (
                   ""

--- a/src/components/Data/AaveClient.js
+++ b/src/components/Data/AaveClient.js
@@ -1,16 +1,15 @@
-
 import { ApolloClient } from "apollo-client";
 import { InMemoryCache } from "apollo-cache-inmemory";
 import { HttpLink } from "apollo-link-http";
 
 export const AaveClient = new ApolloClient({
-    // By default, this client will send queries to the
-    //  `/graphql` endpoint on the same host
-    // Pass the configuration option { uri: YOUR_GRAPHQL_API_URL } to the `HttpLink` to connect
-    // to a different host
-    link: new HttpLink({
-        // pending uniswap with 'fixed' trade volumne
-        uri: "https://api.thegraph.com/subgraphs/name/aave/protocol-v2",
-    }),
-    cache: new InMemoryCache(),
+  // By default, this client will send queries to the
+  //  `/graphql` endpoint on the same host
+  // Pass the configuration option { uri: YOUR_GRAPHQL_API_URL } to the `HttpLink` to connect
+  // to a different host
+  link: new HttpLink({
+    // pending uniswap with 'fixed' trade volumne
+    uri: "https://api.thegraph.com/subgraphs/name/aave/aave-v2-matic",
+  }),
+  cache: new InMemoryCache(),
 });

--- a/src/components/Lend/AaveAction.tsx
+++ b/src/components/Lend/AaveAction.tsx
@@ -21,7 +21,7 @@ export const deposit = async (provider, accountAddress) => {
     // reserve: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
     // DAI reserve polygon
     reserve: "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
-    amount: "10",
+    amount: "1",
   });
 
   //   A Signer in ethers is an abstraction of an Ethereum Account, which can be used to sign messages and transactions

--- a/src/components/account/UserHoldings.tsx
+++ b/src/components/account/UserHoldings.tsx
@@ -1,0 +1,23 @@
+import { ZapperAaveBalance } from "../../models/Zapper";
+declare interface UserHoldingsProps {
+  aaveHoldings: ZapperAaveBalance[];
+}
+
+// This component is in charge of showing a users AaveHoldings.
+//
+// This component is a React functional component more info can be found:
+// https://reactjs.org/docs/components-and-props.html#function-and-class-components
+// It currently shows a tokens label, apy, balance (in USD), balance. It shows
+// all tokens present in aave.
+export const UserHoldingsComponent = ({ aaveHoldings }: UserHoldingsProps) => (
+  <div>
+    {aaveHoldings.map((token, index) => (
+      <div key={index}>
+        <h4>{token.label}</h4>
+        <h5> Current APY: {token.apy}</h5>
+        <div>Balance in USD: {token.balanceUSD}</div>
+        <div>Balance: {token.balance}</div>
+      </div>
+    ))}
+  </div>
+);

--- a/src/models/Zapper.ts
+++ b/src/models/Zapper.ts
@@ -6,8 +6,17 @@ export enum ZapperNetworks {
   polygon = "polygon",
 }
 
+export enum ZapperSupportedProtocolWalletBalances {
+  Aave = "aave-v2",
+}
+
+export enum ZapperSupportedProtocols {
+  Aave = "aave",
+}
+
 // Zapper specific coin symbols to differentiate coins.
 export enum ZapperCoinSymbols {
+  Dai = "DAI",
   eth = "ETH",
 }
 
@@ -17,4 +26,67 @@ export interface ZapperCoinPrice {
   decimals: number;
   symbol: string;
   price: number;
+}
+
+// All models below are specific for Aave (can be generic for Protocols for future versions).
+export enum ZapperAaveTokenCategory {
+  Deposit = "deposit",
+}
+
+export enum ZapperAaveTokenType {
+  EarnsInterest = "interest-bearing",
+}
+
+export interface ZapperAaveBalance {
+  type: string;
+  category: ZapperAaveTokenCategory;
+  address: string;
+  symbol: ZapperCoinSymbols;
+  decimals: number;
+  label: string;
+  img: string;
+  protocol: ZapperSupportedProtocols;
+  protocolDisplay: string;
+  protocolSymbol: string;
+  price: number;
+  apy: number;
+  // Raw balance value.
+  balanceRaw: string;
+  // Number of tokens held.
+  balance: number;
+  // Value of tokens held (price * balace).
+  balanceUSD: number;
+}
+
+export enum ZapperAaveBalanceMetadataLabels {
+  Total = "Total",
+  Assets = "Assets",
+  Debt = "Debt",
+  // Only shows up in `ZapperAaveProductInfo`.
+  Health = "Health Factor",
+}
+
+export interface ZapperAaveBalanceMetadata {
+  label: ZapperAaveBalanceMetadataLabels;
+  value: number;
+  type: string;
+}
+
+export enum ZapperProtocolBalanceProductLabel {
+  AaveV2 = "Aave V2",
+}
+export interface ZapperAaveProductInfo {
+  label: ZapperProtocolBalanceProductLabel;
+  assets: ZapperAaveBalance[];
+  // Only ontains `Health Factor`.
+  meta: ZapperAaveBalanceMetadata;
+}
+
+// Response of /aave-v2 balance for a user.
+export interface ZapperAaveBalanceResponse {
+  [address: string]: {
+    products: ZapperAaveProductInfo[];
+    // Contains Total and Assets values for Aave holdings.
+    meta: ZapperAaveBalanceMetadata[];
+  };
 }

--- a/src/services/ZapperService.ts
+++ b/src/services/ZapperService.ts
@@ -1,9 +1,13 @@
-import { HttpService } from "./HttpService";
 import {
+  ZapperAaveBalance,
+  ZapperAaveBalanceResponse,
   ZapperCoinPrice,
   ZapperCoinSymbols,
   ZapperNetworks,
+  ZapperProtocolBalanceProductLabel,
+  ZapperSupportedProtocolWalletBalances,
 } from "../models/Zapper";
+import { HttpService } from "./HttpService";
 
 const ZapperEndpoint = "/zapper";
 const ZapperApiKey = "96e0cc51-a62e-42ca-acee-910ea7d2a241";
@@ -31,6 +35,38 @@ export class ZapperService {
     } catch (error) {
       console.log("request failed", error);
       return 0;
+    }
+  }
+
+  // This function gets all the tokens in a user wallet.
+  //
+  //This function gets all the tokens a user has lended in aave, as well as each respective APY.
+  static async GetUserAaveHoldings(
+    address: string,
+    protocol: ZapperSupportedProtocolWalletBalances = ZapperSupportedProtocolWalletBalances.Aave,
+    network: ZapperNetworks = ZapperNetworks.polygon
+  ): Promise<ZapperAaveBalance[]> {
+    // Address must always be treated as lowercase for some functions.
+    const standardizedAddress = address.toLowerCase();
+    const endpoint = `v1/protocols/${protocol}/balances`;
+    const params = `?addresses%5B%5D=${standardizedAddress}&network=${network}&api_key=${ZapperApiKey}`;
+    try {
+      const userAaveResponse = (await HttpService.get<ZapperAaveBalanceResponse>(
+        `${ZapperEndpoint}/${endpoint}${params}`
+      )) as ZapperAaveBalanceResponse;
+      const userProducts = userAaveResponse[standardizedAddress];
+      console.log("user account holdings are", userProducts);
+      // Must find the products that are related to "Aave V2".
+      for (const aaveProducts of userProducts.products) {
+        if (aaveProducts.label == ZapperProtocolBalanceProductLabel.AaveV2) {
+          console.log("found aave v2 holdings for user");
+          return aaveProducts.assets;
+        }
+      }
+      return [];
+    } catch (error) {
+      console.log("request failed", error);
+      return [];
     }
   }
 }

--- a/src/services/ZapperService.ts
+++ b/src/services/ZapperService.ts
@@ -38,9 +38,12 @@ export class ZapperService {
     }
   }
 
-  // This function gets all the tokens in a user wallet.
-  //
+  //TODO(adotcruz): Implement function that gets all the tokens in a user wallet.
+
   //This function gets all the tokens a user has lended in aave, as well as each respective APY.
+  //
+  // By default Protocol is set to Aave, and Network is set to Polygon, but this can be made
+  // more generic as more support is added to different protocols/networks.
   static async GetUserAaveHoldings(
     address: string,
     protocol: ZapperSupportedProtocolWalletBalances = ZapperSupportedProtocolWalletBalances.Aave,


### PR DESCRIPTION
Adds use of Zapper API to get a users aave holdings.

Example screenshot:
<img width="818" alt="Screen Shot 2021-05-05 at 2 16 49 PM" src="https://user-images.githubusercontent.com/16697901/117189801-99b9c180-adac-11eb-806e-1ee290987d12.png">

This CL includes:

- New GET Zapper endpoint
- New Zapper models/Zapper supported Aave models
- New React Functional Component to show a users holdings
- More documentation
